### PR TITLE
Memberships changed to Groups in views and app helper to make it less confusing

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -177,7 +177,7 @@ module ApplicationHelper
     return inbox      
   end
   
-  def memberships_link(user, text="My Memberships")
+  def memberships_link(user, text="My Groups")
     opts = nil
     unless (length = user.networks_membership_requests_pending.length + user.memberships_invited.length) == 0
       text = "#{text} (#{length})"

--- a/app/views/memberships/_breadcrumbs.rhtml
+++ b/app/views/memberships/_breadcrumbs.rhtml
@@ -3,9 +3,9 @@
 
   <li><%= name(@user) %></li>
     
-  <li><%= link_to 'Memberships', user_memberships_path(@user) %></li>
+  <li><%= link_to 'Groups', user_memberships_path(@user) %></li>
 <% else %>
-  <li><%= link_to 'Memberships', url_for(:controller => :memberships) %>
+  <li><%= link_to 'Groups', url_for(:controller => :memberships) %>
 <% end %>
 
 <% if ["show"].include? controller.action_name.to_s %>

--- a/app/views/memberships/index.rhtml
+++ b/app/views/memberships/index.rhtml
@@ -2,7 +2,7 @@
 
 	<% if my_page? @user %>
 
-		<h1>My Memberships</h1>
+		<h1>My Groups</h1>
 
 		<% memberships = @user.networks_membership_requests_pending(true) %>
 		<div class="fold">
@@ -124,7 +124,7 @@
 
 	<% else %>
 
-		<h1>Memberships for <%=name @user.id %></h1>
+		<h1>Groups for <%=name @user.id %></h1>
 		<% unless @user.memberships.empty? %>
 			<%= render :partial => "memberships/table", :locals => { :collection => @user.memberships, :user => false } %>
 		<% else %>
@@ -135,7 +135,7 @@
 
 <% else %>
 	<% if false %>
-		<h2>All Memberships</h2>
+		<h2>All Groups</h2>
 
 		<%= render :partial => "layouts/paginate", :locals => { :collection => @memberships } %>
 

--- a/app/views/networks/show.rhtml
+++ b/app/views/networks/show.rhtml
@@ -52,7 +52,7 @@
 	<a href="#creditations">Creditations (<%= @network.creditations.length -%>)</a>
 	|
 	<% if mine? @network %>
-	  <a href="#manage_memberships">Manage Memberships</a>
+	  <a href="#manage_memberships">Manage Groups</a>
 		|
 		<% cnt = @network.memberships_requested.length %>
 		<a href="#requests_pending"><% unless cnt == 0 %><b><% end %>Requests Pending (<%= cnt -%>)<% unless cnt == 0 %></b><% end %></a>
@@ -202,7 +202,7 @@
 
   <% memberships = @network.memberships_accepted %>
 	<div class="tabContainer">
-    <div class="tabTitle">Manage Memberships</div>
+    <div class="tabTitle">Manage Groups</div>
     <div class="tabContent">
       <a name="manage_memberships"></a>
 

--- a/app/views/users/show.rhtml
+++ b/app/views/users/show.rhtml
@@ -57,7 +57,7 @@
 					<li><%= icon('edit', edit_user_profile_path(@user), nil, nil, 'Edit Profile') %></li>
 				<% end %>
 			  <li><%= icon('history', user_userhistory_path(@user), nil, nil, 'View My History')%></li>
-        <li><%= memberships_link(current_user, "My Memberships") %></li>
+        <li><%= memberships_link(current_user, "My Groups") %></li>
         <li><%= icon('network', user_friendships_path(@user), nil, nil, 'My Friendships')%></li>
 	    <% end %>
 
@@ -387,7 +387,7 @@
 	  <% end %>
   
       <% if mine? @user %>
-        <p style="color: #666666;">[ <%= link_to 'View all Memberships in detail', user_memberships_path(@user) %> ]</p>
+        <p style="color: #666666;">[ <%= link_to 'View all Groups in detail', user_memberships_path(@user) %> ]</p>
       <% end %>
 
   <% when "Workflows" %>


### PR DESCRIPTION
Changed various views and the membership_links helper to show the text 'Groups' instead of 'Memberships' so that it is more obvious what the pages are linking to.
